### PR TITLE
Remove unused pathom3 dependency

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -27,7 +27,6 @@
                                      com.fulcrologic/fulcro-devtools-remote {:mvn/version "0.2.8"}
                                      com.fulcrologic/fulcro-inspect         {:mvn/version "1.0.5"}
                                      com.wsscode/pathom                     {:mvn/version "2.4.0"}
-                                     com.wsscode/pathom3                    {:mvn/version "2025.01.16-alpha"}
                                      mount/mount                            {:mvn/version "0.1.23"}
                                      org.clojure/tools.namespace            {:mvn/version "1.5.1"}
                                      thheller/shadow-cljs                   {:mvn/version "3.3.6"}}}


### PR DESCRIPTION
com.wsscode/pathom3 was orphaned after the Pathom 3 support files were deleted during the RAD->statecharts conversion; nothing in src/ references it (the repo uses Pathom 2 only). It also transitively pulled funcool/promesa 8.0.450, which lacks promesa.core/await! and caused com.fulcrologic.statecharts.promise to fail loading during shadow-cljs compilation.